### PR TITLE
Enhance critic inputs and device handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !*/
 # 放行所有 .py 檔案（任何子目錄下）
 !*.py
+!ENVIRONMENT_ASSUMPTIONS.md
 
 # 以下附加規則——忽略虛擬環境和快取
 .venv/

--- a/ENVIRONMENT_ASSUMPTIONS.md
+++ b/ENVIRONMENT_ASSUMPTIONS.md
@@ -1,0 +1,11 @@
+# Environment Assumptions
+
+This project assumes a fixed multi-agent topology and constant observation and action spaces.
+
+* **Fixed number of agents** – `n_agent` does not change during training or evaluation.
+* **Static neighbor mask** – each agent's neighbors are predetermined and remain the same.
+* **Observation and action dimensions are constant** – sizes used to build neural networks never change after initialization.
+* **Single GPU training** – the code is designed for a single device although tensors automatically follow the model's device via the `dev` property.
+* **Optional GAT support** – if `USE_GAT=1` and `torch_geometric` is installed, GAT layers are active; otherwise the model falls back to MLP communication.
+
+These constraints allow the policy and critic networks to allocate all necessary layers during initialization and avoid dynamic rebuilding during runtime.


### PR DESCRIPTION
## Summary
- compute shared value head using max neighbour dimension
- pad critic inputs when neighbour actions unavailable
- cache edge indices in GAT and reuse torch.arange
- remove `self.device` attribute and rely on `self.dev`
- return early for empty batches in GAT application
- pass previous joint actions into `forward` during rollout so critic sees consistent features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and torch)*

------
https://chatgpt.com/codex/tasks/task_e_6848c90382cc8333bbea19429210f83e